### PR TITLE
Unwrapped anchor tags in button tags

### DIFF
--- a/src/components/Button/Button.module.scss
+++ b/src/components/Button/Button.module.scss
@@ -27,6 +27,26 @@ button {
   }
 }
 
+.customButton  {
+  border: 1px solid rgba(0,0,0,.15);
+  background-color: #fff;
+  border-radius: 20px;
+  font-size: 14px;
+  padding: 5px 40px;
+  text-decoration: none;
+  color: black;
+  
+
+  &:first-child {
+    margin-right: 20px;
+  }
+
+  &:hover{
+    color: #fff;
+    background: $themeMainColour;
+  }
+}
+
 @media all and (min-width: 481px) and (max-width: 979px) {
   button {
     border: 1px solid #00000027;
@@ -39,6 +59,9 @@ button {
     a:active {
       padding: 20px 40px;
     }
+  }
+  .customButton {
+    font-size: 10px;
   }
 }
 
@@ -54,5 +77,9 @@ button {
     a:active {
       padding: 10px 20px;
     }
+  }
+
+  .customButton {
+    padding: 10px;
   }
 }

--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -3,11 +3,9 @@ import styles from "./Button.module.scss";
 
 const Button = ({ url, title }) => (
   <div className={styles.Button}>
-    <button>
-      <a href={url} target="_blank" rel="noopener noreferrer">
-        {title}
-      </a>
-    </button>
+    <a className={styles.customButton} href={url} target="_blank" rel="noopener noreferrer">
+      {title}
+    </a>
   </div>
 );
 


### PR DESCRIPTION
I noticed that when u want to hover over the Github and Discord links on the frontpage, the hover effect triggers before you actually point the mouse on the button.

To fix it, I removed the `<button>`, gave the `<a>` a class, and styled the `<a>` to make it look like a button.

There are probably mixed views on putting `<a>` inside a `<button>`, but here's my justification:
The button is more a link than an actual button, so I thought a clean `<a>` tag would fit it.

Cheers :D 

- First time contributing, so I hope I did it right :D 